### PR TITLE
fix: isolate staging/production with docker-compose project names

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -62,15 +62,15 @@ COMMAND_ID=$(aws ssm send-command \
         'export POSTGRES_PASSWORD=\$(cat /opt/secrets/postgres_password)',
         'export DOCKER_BUILDKIT=1',
         'export GIT_COMMIT=\$(git rev-parse --short HEAD)',
-        'docker-compose build',
+        'docker-compose -p filter-ical-$ENVIRONMENT build',
         'echo \"🚀 Starting services...\"',
-        'docker-compose up -d',
+        'docker-compose -p filter-ical-$ENVIRONMENT up -d',
         'echo \"⏳ Waiting for database...\"',
         'sleep 15',
         'echo \"📊 Running migrations...\"',
-        'docker-compose exec -T backend alembic upgrade head || echo \"⚠️  Migrations may have failed\"',
+        'docker-compose -p filter-ical-$ENVIRONMENT exec -T backend alembic upgrade head || echo \"⚠️  Migrations may have failed\"',
         'echo \"✅ $ENVIRONMENT is live on port $BACKEND_PORT!\"',
-        'docker-compose ps'
+        'docker-compose -p filter-ical-$ENVIRONMENT ps'
     ]" \
     --output text \
     --query 'Command.CommandId')


### PR DESCRIPTION
## Problem
Deploying staging overwrites production containers (and vice versa) because docker-compose uses the same container names.

## Solution
- Use Usage:  docker compose [OPTIONS] COMMAND

Define and run multi-container applications with Docker

Options:
      --all-resources              Include all resources, even those not
                                   used by services
      --ansi string                Control when to print ANSI control
                                   characters ("never"|"always"|"auto")
                                   (default "auto")
      --compatibility              Run compose in backward compatibility mode
      --dry-run                    Execute command in dry run mode
      --env-file stringArray       Specify an alternate environment file
  -f, --file stringArray           Compose configuration files
      --parallel int               Control max parallelism, -1 for
                                   unlimited (default -1)
      --profile stringArray        Specify a profile to enable
      --progress string            Set type of progress output (auto,
                                   tty, plain, json, quiet)
      --project-directory string   Specify an alternate working directory
                                   (default: the path of the, first
                                   specified, Compose file)
  -p, --project-name string        Project name

Management Commands:
  bridge      Convert compose files into another model

Commands:
  attach      Attach local standard input, output, and error streams to a service's running container
  build       Build or rebuild services
  commit      Create a new image from a service container's changes
  config      Parse, resolve and render compose file in canonical format
  cp          Copy files/folders between a service container and the local filesystem
  create      Creates containers for a service
  down        Stop and remove containers, networks
  events      Receive real time events from containers
  exec        Execute a command in a running container
  export      Export a service container's filesystem as a tar archive
  images      List images used by the created containers
  kill        Force stop service containers
  logs        View output from containers
  ls          List running compose projects
  pause       Pause services
  port        Print the public port for a port binding
  ps          List containers
  publish     Publish compose application
  pull        Pull service images
  push        Push service images
  restart     Restart service containers
  rm          Removes stopped service containers
  run         Run a one-off command on a service
  scale       Scale services 
  start       Start services
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop services
  top         Display the running processes
  unpause     Unpause services
  up          Create and start containers
  version     Show the Docker Compose version information
  volumes     List volumes
  wait        Block until containers of all (or specified) services stop.
  watch       Watch build context for service and rebuild/refresh containers when files are updated

Run 'docker compose COMMAND --help' for more information on a command. to create separate projects
- Each environment gets its own isolated containers, networks, and volumes
- Both staging and production can run simultaneously on the same EC2 instance

## Impact
- Staging: port 3001
- Production: port 3000
- Both can coexist without conflicts

## Testing
Will redeploy both environments after merge to verify isolation.